### PR TITLE
Increase hero top padding to avoid overlap with sticky nav

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -214,7 +214,7 @@ function App() {
       </nav>
 
       {/* Hero Section */}
-      <section id="home" className="pt-16 bg-gradient-to-br from-blue-50 to-indigo-100">
+      <section id="home" className="pt-24 bg-gradient-to-br from-blue-50 to-indigo-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
           <div className="text-center">
             <img src={logo} alt="Lehigh Valley Wellness" className="mx-auto mb-8 h-28 w-auto drop-shadow-lg" />
@@ -564,4 +564,3 @@ function App() {
 }
 
 export default App;
-


### PR DESCRIPTION
### Motivation
- The fixed navigation bar was overlapping the hero heading on scroll, making the main heading partially hidden. 
- Ensure the hero content is fully visible below the sticky nav without changing nav layout or height. 

### Description
- Increased the hero section top padding by changing the Tailwind class from `pt-16` to `pt-24` in `website/src/App.jsx`.
- This is a minimal layout adjustment that preserves existing styles and responsive behavior. 

### Testing
- Started the dev server with `pnpm --dir website dev --host 0.0.0.0 --port 4173` and it launched successfully. 
- Ran a Playwright script to navigate to `http://127.0.0.1:4173` and capture a screenshot (`artifacts/hero-padding.png`) to verify spacing, which completed successfully. 
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655f12a6688333aea4fc67dab7f634)